### PR TITLE
simplified unnecessary if

### DIFF
--- a/api.go
+++ b/api.go
@@ -61,11 +61,8 @@ func (b *Bot) sendFiles(
 				return err
 			}
 
-			if _, err = io.Copy(part, file); err != nil {
-				return err
-			}
-
-			return nil
+			_, err = io.Copy(part, file)
+			return err
 		} (); err != nil {
 			return nil, wrapSystem(err)
 		}


### PR DESCRIPTION
You can remove this if and just directly return err since it's nil if there is no error